### PR TITLE
fix: set querystring_auth to False

### DIFF
--- a/jupyterlitexblock/storage.py
+++ b/jupyterlitexblock/storage.py
@@ -14,6 +14,7 @@ class S3JupyterLiteStorage(S3Boto3Storage):
         self.xblock = xblock
         super().__init__(
             bucket_name=bucket_name,
+            querystring_auth=False,
         )
 
 


### PR DESCRIPTION
set querystring_auth to `False` to avoid signed urls being generated for notebooks